### PR TITLE
Allow custom SVGs to render properly in icon component

### DIFF
--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
+import { equal, readOnly } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
 import layout from '../templates/components/polaris-icon';
@@ -101,6 +101,7 @@ export default Component.extend(SvgHandling, {
   }),
 
   'data-test-icon': true,
+  'data-test-keep-fills': readOnly('keepFills'),
 
   /**
    * Whether the component should leave space for an icon

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -193,3 +193,36 @@ test('it handles placeholder icons correctly', function(assert) {
   const iconPlaceholders = findAll(iconPlaceholderSelector);
   assert.equal(iconPlaceholders.length, 1, 'renders one icon placeholder');
 });
+
+/**
+ * Internal tests
+ */
+test('it removes icon fills when no sourcePath is specified and source does not contain a slash', function(assert) {
+  this.render(hbs`{{polaris-icon source="placeholder"}}`);
+
+  assert.dom(iconSelector).doesNotHaveAttribute('data-test-keep-fills');
+});
+
+test('it removes icon fills when no sourcePath is specified and source contains "polaris/"', function(assert) {
+  this.render(hbs`{{polaris-icon source="polaris/placeholder"}}`);
+
+  assert.dom(iconSelector).doesNotHaveAttribute('data-test-keep-fills');
+});
+
+test('it removes icon fills when sourcePath is specified as "polaris"', function(assert) {
+  this.render(hbs`{{polaris-icon sourcePath="polaris" source="placeholder"}}`);
+
+  assert.dom(iconSelector).doesNotHaveAttribute('data-test-keep-fills');
+});
+
+test('it keeps icon fills when sourcePath is not "polaris"', function(assert) {
+  this.render(hbs`{{polaris-icon sourcePath="custom-icons" source="my-icon"}}`);
+
+  assert.dom(iconSelector).hasAttribute('data-test-keep-fills');
+});
+
+test('it keeps icon fills when no sourcePath is specified and source contains a slash', function(assert) {
+  this.render(hbs`{{polaris-icon source="custom-icons/my-icon"}}`);
+
+  assert.dom(iconSelector).hasAttribute('data-test-keep-fills');
+});


### PR DESCRIPTION
Moves our [`keepFills`](https://github.com/smile-io/ember-smile-polaris/blob/master/addon/components/polaris-icon.js#L15) custom behaviour in `polaris-icon` across from `ember-smile-polaris`.