### PR TITLE
Add support for illustrationSize property on polaris-callout-card

### DIFF
--- a/addon/components/polaris-callout-card.js
+++ b/addon/components/polaris-callout-card.js
@@ -1,5 +1,10 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import layout from '../templates/components/polaris-callout-card';
+
+const illustrationSizeClasses = {
+  large: 'illustration-large',
+};
 
 /**
  * Polaris callout card component.
@@ -7,6 +12,7 @@ import layout from '../templates/components/polaris-callout-card';
  */
 export default Component.extend({
   classNames: ['Polaris-Card'],
+  classNameBindings: ['illustrationSizeClass'],
 
   layout,
 
@@ -58,4 +64,24 @@ export default Component.extend({
    * @default null
    */
   secondaryAction: null,
+
+  /**
+   * Allows overriding the illustration size.
+   * This is an addition to the Polaris spec.
+   *
+   * @property illustrationSize
+   * @type {String}
+   * @default null
+   */
+  illustrationSize: null,
+
+  /**
+   * Class name to apply illustration size override.
+   *
+   * @property illustrationSizeClass
+   * @type {String}
+   */
+  illustrationSizeClass: computed('illustrationSize', function() {
+    return illustrationSizeClasses[this.get('illustrationSize')] || null;
+  }).readOnly(),
 });

--- a/app/styles/components/polaris-callout-card.scss
+++ b/app/styles/components/polaris-callout-card.scss
@@ -1,0 +1,7 @@
+.Polaris-Card {
+  &.illustration-large {
+    .Polaris-CalloutCard__Image {
+      flex-basis: 30%;
+    }
+  }
+}

--- a/app/styles/ember-polaris.scss
+++ b/app/styles/ember-polaris.scss
@@ -1,3 +1,4 @@
 @import './ember-polaris/styles';
 
+@import 'components/polaris-callout-card';
 @import 'components/polaris-popover';

--- a/tests/integration/components/polaris-callout-card-test.js
+++ b/tests/integration/components/polaris-callout-card-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, click } from 'ember-native-dom-helpers';
+import { find, findAll, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 moduleForComponent(
@@ -215,4 +215,39 @@ test('it handles actions correctly', function(assert) {
     this.get('secondaryActionFired'),
     'after firing secondary action - secondary action has been fired'
   );
+});
+
+/************************************\
+| Tests for internal customisations. |
+\************************************/
+test('it overrides the image size when illustrationSize is set to "large"', function(assert) {
+  this.render(hbs`
+    {{polaris-callout-card
+      illustration="http://www.somewhere.com/some-image.jpg"
+      illustrationSize="large"
+      primaryAction=(hash
+        text="Primary"
+        onAction=(action (mut dummy))
+      )
+    }}
+  `);
+
+  let illustration = find(calloutCardImageSelector);
+  assert.equal(getComputedStyle(illustration).flexBasis, '30%');
+});
+
+test('it does not override the image size when illustrationSize is set to a random value', function(assert) {
+  this.render(hbs`
+    {{polaris-callout-card
+      illustration="http://www.somewhere.com/some-image.jpg"
+      illustrationSize="unspecified"
+      primaryAction=(hash
+        text="Primary"
+        onAction=(action (mut dummy))
+      )
+    }}
+  `);
+
+  let illustration = find(calloutCardImageSelector);
+  assert.equal(getComputedStyle(illustration).flexBasis, 'auto');
 });


### PR DESCRIPTION
Allows passing an `illustrationSize` string to `polaris-callout-card`, to allow us some control over the size the image is rendered.