### PR TITLE
Fix blurring popover activator when closed via popover.close action

### DIFF
--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -1,7 +1,7 @@
 {{#basic-dropdown
   verticalPosition=verticalPosition
   onOpen=(action "onOpen")
-  onClose=(action onClose)
+  onClose=(action "onClose")
   as |dd|
 }}
   {{yield

--- a/tests/integration/components/polaris-popover-test.js
+++ b/tests/integration/components/polaris-popover-test.js
@@ -263,9 +263,7 @@ test('it applies the supplied contentClass to the content component when popover
   assert.dom(popoverContentSelector).hasClass('test-content-class');
 });
 
-// TODO: this seems to pass whether the onClose changes are present or not,
-// but the changes are still needed for our apps to handle this properly ¯\_(ツ)_/¯
-test('it blurs the trigger when the popover is closed', function(assert) {
+test('it blurs the trigger when the popover is closed via popover.close action', function(assert) {
   this.render(hbs`
     {{#polaris-popover
       as |popover|
@@ -275,7 +273,9 @@ test('it blurs the trigger when the popover is closed', function(assert) {
       {{/popover.activator}}
 
       {{#popover.content}}
-        This is some popover content
+        <div>This is some popover content</div>
+
+        <button id="close-popover" {{action popover.close}}>Close popover</button>
       {{/popover.content}}
     {{/polaris-popover}}
   `);
@@ -283,8 +283,8 @@ test('it blurs the trigger when the popover is closed', function(assert) {
   // open the popover
   click(activatorSelector);
 
-  // close the popover
-  click(activatorSelector);
+  // close the popover via the popover.close action
+  click('#close-popover');
 
   assert.dom('.ember-basic-dropdown-trigger').isNotFocused();
 });


### PR DESCRIPTION
Noticed in manage that blurring the popover activator wasn't happening on the VIP settings' program start date picker. Turned out to be a simple oopsy caused by not calling the right action. Fixed this and also updated the test I built previously so that it now actually fails if our customisations aren't present, instead of passing either way 🙏 