### PR TITLE
Add support for renderInPlace to popover

### DIFF
--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -123,6 +123,17 @@ export default Component.extend({
   contentClass: null,
 
   /**
+   * Flag to allow inlining popover when we need to adjust styling
+   * This is an addition to the base Polaris implementation
+   *
+   * @property renderInPlace
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  renderInPlace: false,
+
+  /**
    * Callback when popover is opened
    * This is an addition to the base Polaris implementation
    *

--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -1,5 +1,6 @@
 {{#basic-dropdown
   verticalPosition=verticalPosition
+  renderInPlace=renderInPlace
   onOpen=(action "onOpen")
   onClose=(action "onClose")
   as |dd|

--- a/tests/integration/components/polaris-popover-test.js
+++ b/tests/integration/components/polaris-popover-test.js
@@ -319,3 +319,29 @@ test('it calls a passed-in onOpen action when opened', function(assert) {
     'the passed-in onOpen action is called when popover is opened'
   );
 });
+
+test('it honors the renderInPlace flag', function(assert) {
+  this.render(hbs`
+    {{#polaris-popover
+      renderInPlace=true
+      as |popover|
+    }}
+      {{#popover.activator}}
+        {{polaris-button text="Toggle popover"}}
+      {{/popover.activator}}
+
+      {{#popover.content}}
+        <div data-test-inline-content>This is some popover content</div>
+      {{/popover.content}}
+    {{/polaris-popover}}
+  `);
+
+  // open the popover
+  click(activatorSelector);
+
+  assert
+    .dom(
+      `.ember-basic-dropdown-content-wormhole-origin [data-test-inline-content]`
+    )
+    .exists({ count: 1 });
+});


### PR DESCRIPTION
Noticed that popover positioning on our `popup-menu-trigger` component was broken, turned out to be because the `renderInPlace` functionality we previously had got lost in our recent addon reshuffle. So I'm adding it back in to make sure our popup menus render correctly.

Before:
![image](https://user-images.githubusercontent.com/5737342/54032866-76d6f700-41bb-11e9-9062-c1eac309e900.png)

After:
![image](https://user-images.githubusercontent.com/5737342/54032838-632b9080-41bb-11e9-9434-3223d7ebc71b.png)
