### PR TITLE
Add onDismiss support to callout card

### DIFF
--- a/addon/components/polaris-callout-card.js
+++ b/addon/components/polaris-callout-card.js
@@ -66,14 +66,26 @@ export default Component.extend({
   secondaryAction: null,
 
   /**
-   * Allows overriding the illustration size.
-   * This is an addition to the Polaris spec.
+   * Allows overriding the illustration size
+   * This is an addition to the Polaris spec
    *
    * @property illustrationSize
    * @type {String}
    * @default null
    */
   illustrationSize: null,
+
+  /**
+   * Callback when banner is dismissed
+   * TODO: Move this into `ember-polaris` when we
+   * update our target Polaris version to v3.4.0
+   * or later
+   *
+   * @property onDismiss
+   * @type {Function}
+   * @default null
+   */
+  onDismiss: null,
 
   /**
    * Class name to apply illustration size override.

--- a/addon/templates/components/polaris-callout-card.hbs
+++ b/addon/templates/components/polaris-callout-card.hbs
@@ -30,7 +30,7 @@
         {{/polaris-text-container}}
 
         <div class="Polaris-CalloutCard__Buttons">
-          {{#let
+          {{#with
             (component "polaris-button"
               text=primaryAction.text
               accessibilityLabel=primaryAction.accessibilityLabel
@@ -60,7 +60,7 @@
             {{else}}
               {{component primaryButton}}
             {{/if}}
-          {{/let}}
+          {{/with}}
         </div>
       </div>
 

--- a/addon/templates/components/polaris-callout-card.hbs
+++ b/addon/templates/components/polaris-callout-card.hbs
@@ -1,55 +1,76 @@
-{{#polaris-card/section}}
-  <div class="Polaris-CalloutCard">
-    <div class="Polaris-CalloutCard__Content">
-      <div class="Polaris-CalloutCard__Title">
-        {{polaris-heading text=title}}
-      </div>
-
-      {{#polaris-text-container}}
-        {{#if hasBlock}}
-          {{yield}}
-        {{else}}
-          {{text}}
-        {{/if}}
-      {{/polaris-text-container}}
-
-      <div class="Polaris-CalloutCard__Buttons">
-        {{! template-lint-disable attribute-indentation }}
-        {{!-- TODO remove rule above once linter handles this correctly --}}
-        {{#with
-          (component "polaris-button"
-            text=primaryAction.text
-            accessibilityLabel=primaryAction.accessibilityLabel
-            disabled=primaryAction.disabled
-            primary=primaryAction.primary
-            destructive=primaryAction.destructive
-            icon=primaryAction.icon
-            loading=primaryAction.loading
-            onClick=(action primaryAction.onAction)
-          )
-          as |primaryButton|
-        }}
-          {{#if secondaryAction}}
-            {{#polaris-button-group}}
-              {{component primaryButton}}
-
-              {{polaris-button
-                plain=true
-                text=secondaryAction.text
-                accessibilityLabel=secondaryAction.accessibilityLabel
-                disabled=secondaryAction.disabled
-                icon=secondaryAction.icon
-                loading=secondaryAction.loading
-                onClick=(action secondaryAction.onAction)
-              }}
-            {{/polaris-button-group}}
-          {{else}}
-            {{component primaryButton}}
-          {{/if}}
-        {{/with}}
-      </div>
+{{!--
+  TODO: Move this entire template into `ember-polaris` when we
+  update our target Polaris version to v3.4.0 or later.
+--}}
+<div class="Polaris-CalloutCard__Container">
+  {{#if onDismiss}}
+    <div class="Polaris-CalloutCard__Dismiss">
+      {{polaris-button
+        plain=true
+        icon="cancel-small"
+        onClick=(action onDismiss)
+        accessibilityLabel="Dismiss card"
+      }}
     </div>
+  {{/if}}
 
-    <img src={{illustration}} alt="" class="Polaris-CalloutCard__Image">
-  </div>
-{{/polaris-card/section}}
+  {{#polaris-card/section}}
+    <div class="Polaris-CalloutCard">
+      <div class="Polaris-CalloutCard__Content">
+        <div class="Polaris-CalloutCard__Title">
+          {{polaris-heading text=title}}
+        </div>
+
+        {{#polaris-text-container}}
+          {{#if hasBlock}}
+            {{yield}}
+          {{else}}
+            {{text}}
+          {{/if}}
+        {{/polaris-text-container}}
+
+        <div class="Polaris-CalloutCard__Buttons">
+          {{! template-lint-disable attribute-indentation }}
+          {{!-- TODO remove rule above once linter handles this correctly --}}
+          {{#with
+            (component "polaris-button"
+              text=primaryAction.text
+              accessibilityLabel=primaryAction.accessibilityLabel
+              disabled=primaryAction.disabled
+              primary=primaryAction.primary
+              destructive=primaryAction.destructive
+              icon=primaryAction.icon
+              loading=primaryAction.loading
+              onClick=(action primaryAction.onAction)
+            )
+            as |primaryButton|
+          }}
+            {{#if secondaryAction}}
+              {{#polaris-button-group}}
+                {{component primaryButton}}
+
+                {{polaris-button
+                  plain=true
+                  text=secondaryAction.text
+                  accessibilityLabel=secondaryAction.accessibilityLabel
+                  disabled=secondaryAction.disabled
+                  icon=secondaryAction.icon
+                  loading=secondaryAction.loading
+                  onClick=(action secondaryAction.onAction)
+                }}
+              {{/polaris-button-group}}
+            {{else}}
+              {{component primaryButton}}
+            {{/if}}
+          {{/with}}
+        </div>
+      </div>
+
+      <img
+        alt=""
+        class="Polaris-CalloutCard__Image {{if onDismiss "Polaris-CalloutCard__DismissImage"}}"
+        src={{illustration}}
+      >
+    </div>
+  {{/polaris-card/section}}
+</div>

--- a/addon/templates/components/polaris-callout-card.hbs
+++ b/addon/templates/components/polaris-callout-card.hbs
@@ -8,8 +8,8 @@
       {{polaris-button
         plain=true
         icon="cancel-small"
-        onClick=(action onDismiss)
         accessibilityLabel="Dismiss card"
+        onClick=(action onDismiss)
       }}
     </div>
   {{/if}}
@@ -30,9 +30,7 @@
         {{/polaris-text-container}}
 
         <div class="Polaris-CalloutCard__Buttons">
-          {{! template-lint-disable attribute-indentation }}
-          {{!-- TODO remove rule above once linter handles this correctly --}}
-          {{#with
+          {{#let
             (component "polaris-button"
               text=primaryAction.text
               accessibilityLabel=primaryAction.accessibilityLabel
@@ -62,7 +60,7 @@
             {{else}}
               {{component primaryButton}}
             {{/if}}
-          {{/with}}
+          {{/let}}
         </div>
       </div>
 

--- a/app/styles/components/polaris-callout-card.scss
+++ b/app/styles/components/polaris-callout-card.scss
@@ -5,3 +5,19 @@
     }
   }
 }
+
+// TODO: remove these when we update to Polaris v3.4.0 or later
+// since they'll be included in the Polaris styles at that point.
+.Polaris-__CalloutCard__DismissImage {
+  margin-right: spacing(loose);
+}
+
+.Polaris-CalloutCard__Container {
+  position: relative;
+}
+
+.Polaris-CalloutCard__Dismiss {
+  right: spacing();
+  top: spacing();
+  position: absolute;
+}

--- a/tests/integration/components/polaris-callout-card-test.js
+++ b/tests/integration/components/polaris-callout-card-test.js
@@ -13,6 +13,7 @@ moduleForComponent(
 
 const calloutCardSelector = buildNestedSelector(
   'div.Polaris-Card',
+  'div.Polaris-CalloutCard__Container',
   'div.Polaris-Card__Section',
   'div.Polaris-CalloutCard'
 );
@@ -215,6 +216,26 @@ test('it handles actions correctly', function(assert) {
     this.get('secondaryActionFired'),
     'after firing secondary action - secondary action has been fired'
   );
+});
+
+// TODO: Move this into `ember-polaris` when we
+// update our target Polaris version to v3.4.0
+// or later.
+test('it is dismissed', function(assert) {
+  this.render(hbs`
+    {{polaris-callout-card
+      primaryAction=(hash
+        text="Primary"
+        onAction=(action (mut primaryActionFired) true)
+      )
+      onDismiss=(action (mut wasOnDismissCalled) true)
+    }}
+  `);
+
+  assert.dom('.Polaris-Button').exists({ count: 2 });
+
+  click('.Polaris-Button');
+  assert.ok(this.get('wasOnDismissCalled'));
 });
 
 /************************************\


### PR DESCRIPTION
Adds `onDismiss` support to `polaris-callout-card`. This is available in Polaris from v3.4.0 onwards, but `ember-polaris` currently targets v2.11.0 which doesn't have the styles etc. required for this. For that reason, I'm adding it here and we can move it into `ember-polaris` as and when we update the target version of Polaris to >= v3.4.0.

For reference, https://github.com/Shopify/polaris-react/pull/714 is where the `onDismiss` functionality was added to the React implementation.