### PR TITLE
Ignore number of uploaded files in drop zone to avoid component "freezing"

### DIFF
--- a/addon/components/polaris-drop-zone.js
+++ b/addon/components/polaris-drop-zone.js
@@ -381,7 +381,9 @@ export default Component.extend(ContextBoundEventListenersMixin, {
     state.setProperties({
       dragging: false,
       error: rejectedFiles.length > 0,
-      numFiles: state.get('numFiles') + acceptedFiles.length,
+      // TODO: uncomment this line when there's a fix for
+      // https://github.com/Shopify/polaris-react/issues/1229.
+      // numFiles: state.get('numFiles') + acceptedFiles.length,
     });
 
     onDrop(files, acceptedFiles, rejectedFiles);

--- a/tests/integration/components/polaris-drop-zone-test.js
+++ b/tests/integration/components/polaris-drop-zone-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -1200,7 +1200,8 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
       await triggerEvent(dropZoneSelector, 'click', event);
     });
 
-    test('does not call callbacks when not allowed multiple and a file is uploaded', async function(assert) {
+    // TODO: unskip this when a fix is available for https://github.com/Shopify/polaris-react/issues/1229.
+    skip('does not call callbacks when not allowed multiple and a file is uploaded', async function(assert) {
       let expectedAcceptedFiles = uploadedFiles.slice(0, 1);
       let expectedRejectedFiles = uploadedFiles.slice(1, 3);
 


### PR DESCRIPTION
The Polaris v3.10.0 update introduced a drop zone feature where the component would ignore user interaction if `allowMultiple` is `false` and the user has already picked a file. This creates an issue where if the user selects a file, and the UI allows them to remove that file, the drop zone ignores any further interaction making selecting a file impossible (see https://github.com/Shopify/polaris-react/issues/1229).

To avoid this for the time being, I'm commenting out the line where we increment the drop zone's internal count of how many files have been selected. We can keep an eye on https://github.com/Shopify/polaris-react/issues/1229 and update `ember-polaris` accordingly as and when a fix becomes available 🙏 