### PR TITLE
Check for media the arg vs media the service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - '8'
 
 sudo: false
 dist: trusty
@@ -27,8 +27,8 @@ jobs:
   include:
     # runs linting and tests with current locked deps
 
-    - stage: "Tests"
-      name: "Tests"
+    - stage: 'Tests'
+      name: 'Tests'
       script:
         - yarn lint:hbs
         - yarn lint:js
@@ -36,8 +36,7 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.18
+    - stage: 'Additional Tests'
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: 'Additional Tests'
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+      env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/addon/templates/components/polaris-option-list/option.hbs
+++ b/addon/templates/components/polaris-option-list/option.hbs
@@ -20,8 +20,8 @@
       }}
     </div>
 
-    {{#if media}}
-      <div class="Polaris-OptionList-Option__Media">{{render-content media}}</div>
+    {{#if @media}}
+      <div class="Polaris-OptionList-Option__Media">{{render-content @media}}</div>
     {{/if}}
 
     {{render-content label}}
@@ -42,8 +42,8 @@
     onfocus={{action "toggleFocus"}}
     onblur={{action "toggleFocus"}}
   >
-    {{#if media}}
-      <div class="Polaris-OptionList-Option__Media">{{render-content media}}</div>
+    {{#if @media}}
+      <div class="Polaris-OptionList-Option__Media">{{render-content @media}}</div>
     {{/if}}
 
     {{render-content label}}

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -29,7 +29,7 @@
   class="Polaris-ResourceList-Item__Container"
   id={{itemId}}
 >
-  {{#if (or media selectable)}}
+  {{#if (or @media selectable)}}
     <div class="Polaris-ResourceList-Item__Owned">
       {{#if selectable}}
         {{#wrapper-element
@@ -55,9 +55,9 @@
         {{/wrapper-element}}
       {{/if}}
 
-      {{#if media}}
+      {{#if @media}}
         <div class="Polaris-ResourceList-Item__Media" data-test-id="media">
-          {{render-content media}}
+          {{render-content @media}}
         </div>
       {{/if}}
     </div>

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,20 +12,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true,
-            }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.4',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Turns out there's a service called `media` that ends up being used when we don't pass in `media` the argument (see screenshot below which doesn't have a media arg passed to it). Luckily the new `@arg` syntax solves this & makes it work as expected.

<img width="1313" alt="Screenshot 2019-05-29 at 8 05 53 PM" src="https://user-images.githubusercontent.com/604117/58566276-eeae3e00-824d-11e9-8fbe-fbddd13a4194.png">
