### PR TITLE
Remove no longer existing component exports

### DIFF
--- a/app/components/polaris-button/button.js
+++ b/app/components/polaris-button/button.js
@@ -1,1 +1,0 @@
-export { default } from '@smile-io/ember-smile-polaris/components/polaris-button/button';

--- a/app/components/polaris-button/link.js
+++ b/app/components/polaris-button/link.js
@@ -1,1 +1,0 @@
-export { default } from '@smile-io/ember-smile-polaris/components/polaris-button/link';


### PR DESCRIPTION
This is something to be aware of when merging from upstream `ember-polaris`...deleted files might be left around orphaned