### PR TITLE
Add "titleAlignment" attribute to PolarisPage

### DIFF
--- a/addon/templates/components/polaris-page.hbs
+++ b/addon/templates/components/polaris-page.hbs
@@ -2,6 +2,7 @@
   {{polaris-page/header
     title=title
     titleMetadata=titleMetadata
+    titleAlignment=titleAlignment
     titleHidden=titleHidden
     icon=icon
     breadcrumbs=breadcrumbs

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -47,7 +47,7 @@
         class=(if primaryAction "Polaris-Page-Header__TitleAndActions")
       }}
         <div class="Polaris-Page-Header__TitleAndRollup">
-          <div class="Polaris-Page-Header__Title">
+          <div class="Polaris-Page-Header__Title {{if (eq titleAlignment "center") "Polaris-Page-Header__Title--alignmentCenter"}}">
             <div>
               {{#polaris-stack alignment="baseline" spacing="tight" as |stack|}}
                 {{#if beforeTitleComponent}}

--- a/app/styles/components/polaris-page/header.scss
+++ b/app/styles/components/polaris-page/header.scss
@@ -1,0 +1,5 @@
+.Polaris-Page-Header__Title {
+  &.Polaris-Page-Header__Title--alignmentCenter {
+    align-items: center;
+  }
+}

--- a/app/styles/ember-smile-polaris.scss
+++ b/app/styles/ember-smile-polaris.scss
@@ -3,3 +3,4 @@
 @import 'components/polaris-callout-card';
 @import 'components/polaris-popover';
 @import 'components/polaris-choice';
+@import 'components/polaris-page/header';


### PR DESCRIPTION
Small improvement to `PolarisPage::Header`, adds a `titleAlignment` attribute so we can center-align the `title` and `titleMetadata` attributes if we want to.

Default is `baseline` alignment and it looks kinda funky with a title/badge combo.

![header](https://user-images.githubusercontent.com/2292367/74459757-76c28b00-4e51-11ea-88c2-4429f0e6fec2.gif)
