### PR TITLE
Add image and description attrs to PolarisResourceList

### DIFF
--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -213,6 +213,26 @@ export default Component.extend(
     idForItem: null,
 
     /**
+     * Whether or not to render the Polaris "empty search results" illustration
+     *
+     * @property shouldRenderEmptyStateIllustration
+     * @type {Boolean}
+     * @default true
+     * @public
+     */
+    shouldRenderEmptyStateIllustration: true,
+
+    /**
+     * Optional description for empty search results
+     *
+     * @property emptyStateDescription
+     * @type {String}
+     * @default 'Try changing the filters or search term'
+     * @public
+     */
+    emptyStateDescription: 'Try changing the filters or search term',
+
+    /**
      * Callback when sort option is changed
      *
      * @property onSortChange

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -139,8 +139,8 @@
       {{else if showEmptyState}}
         <div class="Polaris-ResourceList__EmptySearchResultWrapper">
           {{polaris-empty-search-result
-            withIllustration=true
-            description="Try changing the filters or search term"
+            withIllustration=shouldRenderEmptyStateIllustration
+            description=emptyStateDescription
             title=emptySearchResultTitle
           }}
         </div>


### PR DESCRIPTION
Adds 2 new attributes to our `PolarisResourceList` component:

- `shouldRenderEmptyStateIllustration` to opt out of rendering the empty search illustration
- `emptyStateDescription` opt out of rendering any additional help text other than the "no results" message.

Normally defaults would be `null` or `false` values; the defaults here reflect the current values being used in order to maintain backwards compatibility so that we don't have to update all our apps by passing in values for these new attributes.

- - -

Demo without passing attributes (current):

<img width="1003" alt="Screen Shot 2020-03-17 at 2 12 09 PM" src="https://user-images.githubusercontent.com/2292367/76887891-53786a80-6859-11ea-91a8-f400e2dfd479.png">

 Demo with passing `false` and `null` values for new attributes:

<img width="1184" alt="Screen Shot 2020-03-17 at 1 19 39 PM" src="https://user-images.githubusercontent.com/2292367/76887954-6db24880-6859-11ea-9cb7-526ba0ce80a9.png">
