### PR TITLE
[ENHANCEMENT] Add afterTitleComponent to PolarisPage

### DIFF
--- a/addon/components/polaris-page.js
+++ b/addon/components/polaris-page.js
@@ -157,6 +157,15 @@ export default class PolarisPage extends Component {
   beforeTitleComponent = null;
 
   /**
+   * Optional component to be rendered opposite the title text.
+   *
+   * @type {String|Component|Object}
+   * @default null
+   * @extends ember-polaris
+   */
+  afterTitleComponent = null;
+
+  /**
    * Title alignment.
    * Supported values: 'center'
    *

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -118,6 +118,15 @@ export default class PolarisPageHeader extends Component {
    */
   beforeTitleComponent = null;
 
+  /**
+   * Optional component to be rendered opposite the title text.
+   *
+   * @type {String|Component|Object}
+   * @default null
+   * @extends ember-polaris
+   */
+  afterTitleComponent = null;
+
   @gt('breadcrumbs.length', 0)
   hasBreadcrumbs;
 

--- a/addon/templates/components/polaris-page.hbs
+++ b/addon/templates/components/polaris-page.hbs
@@ -13,6 +13,7 @@
       @primaryAction={{@primaryAction}}
       @pagination={{@pagination}}
       @beforeTitleComponent={{@beforeTitleComponent}}
+      @afterTitleComponent={{@afterTitleComponent}}
     />
   {{/if}}
 

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -39,9 +39,9 @@
             <div>
               <PolarisStack @alignment="baseline" @spacing="tight" as |stack|>
                 {{#if @beforeTitleComponent}}
-                  {{#stack.item}}
+                  <stack.item>
                     {{render-content @beforeTitleComponent}}
-                  {{/stack.item}}
+                  </stack.item>
                 {{/if}}
 
                 <PolarisDisplayText
@@ -58,6 +58,12 @@
               {{/if}}
             </div>
           </div>
+
+          {{#if @afterTitleComponent}}
+            <div>
+              {{render-content @afterTitleComponent}}
+            </div>
+          {{/if}}
 
           {{#unless this.hasBreadcrumbs}}
             <Rollup />

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -532,6 +532,17 @@ module('Integration | Component | polaris page', function(hooks) {
     assert.dom('.before-title-component').exists({ count: 1 });
   });
 
+  test('it renders a afterTitleComponent when one is passed', async function(assert) {
+    await render(hbs`
+        <PolarisPage
+          @title="Page title"
+          @afterTitleComponent={{component "wrapper-element" class="after-title-component"}}
+        />
+      `);
+
+    assert.dom('.after-title-component').exists({ count: 1 });
+  });
+
   test('it removes fills from custom icons in secondary actions', async function(assert) {
     await render(hbs`
         {{polaris-page


### PR DESCRIPTION
Extends `PolarisPage` to support an `afterTitleComponent` parameter, which renders right-aligned in line with the title:

![image](https://user-images.githubusercontent.com/5737342/88260974-1a03b000-ccce-11ea-8006-5b77a8cdd155.png)
