### PR TITLE
Allow horizontal layout for card sections

### DIFF
--- a/addon/components/polaris-card.js
+++ b/addon/components/polaris-card.js
@@ -80,10 +80,10 @@ export default class PolarisCard extends Component {
    * Allows card sections to be arranged horizontally instead of vertically
    * This is an addition to the Polaris spec
    *
-   * @property rowSections
-   * @type {Boolean}
-   * @default null
+   * @property sectionDirection
+   * @type {String}
+   * @default 'column'
    * @extends ember-polaris
    */
-  rowSections = null;
+  sectionDirection = 'column';
 }

--- a/addon/components/polaris-card.js
+++ b/addon/components/polaris-card.js
@@ -75,4 +75,15 @@ export default class PolarisCard extends Component {
    * @default null
    */
   secondaryFooterAction = null;
+
+  /**
+   * Allows card sections to be arranged horizontally instead of vertically
+   * This is an addition to the Polaris spec
+   *
+   * @property rowSections
+   * @type {Boolean}
+   * @default null
+   * @extends ember-polaris
+   */
+  rowSections = null;
 }

--- a/addon/templates/components/polaris-card.hbs
+++ b/addon/templates/components/polaris-card.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-Card {{@class}} {{if @subdued "Polaris-Card--subdued"}} {{if @rowSections "Polaris-Card--rowSections"}}"
+  class="Polaris-Card {{@class}} {{if @subdued "Polaris-Card--subdued"}} {{if (eq @sectionDirection "row") "Polaris-Card--rowSectionDirection"}}"
   ...attributes
 >
   {{#if (or @title @headerActions)}}

--- a/addon/templates/components/polaris-card.hbs
+++ b/addon/templates/components/polaris-card.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-Card {{@class}} {{if @subdued "Polaris-Card--subdued"}}"
+  class="Polaris-Card {{@class}} {{if @subdued "Polaris-Card--subdued"}} {{if @rowSections "Polaris-Card--rowSections"}}"
   ...attributes
 >
   {{#if (or @title @headerActions)}}

--- a/app/styles/components/polaris-card.scss
+++ b/app/styles/components/polaris-card.scss
@@ -1,0 +1,15 @@
+.Polaris-Card {
+  &.Polaris-Card--rowSections {
+    display: flex;
+    flex-direction: row;
+
+    & > .Polaris-Card__Section {
+      flex: 1 1 auto;
+
+      & + .Polaris-Card__Section {
+        border-top: none;
+        border-left: border();
+      }
+    }
+  }
+}

--- a/app/styles/components/polaris-card.scss
+++ b/app/styles/components/polaris-card.scss
@@ -1,5 +1,5 @@
 .Polaris-Card {
-  &.Polaris-Card--rowSections {
+  &.Polaris-Card--rowSectionDirection {
     display: flex;
     flex-direction: row;
 

--- a/app/styles/ember-smile-polaris.scss
+++ b/app/styles/ember-smile-polaris.scss
@@ -1,6 +1,7 @@
 @import './ember-smile-polaris/styles';
 
 @import 'components/polaris-callout-card';
+@import 'components/polaris-card';
 @import 'components/polaris-popover';
 @import 'components/polaris-choice';
 @import 'components/polaris-page/header';

--- a/tests/integration/components/polaris-card-test.js
+++ b/tests/integration/components/polaris-card-test.js
@@ -469,4 +469,30 @@ module('Integration | Component | polaris card', function (hooks) {
     this.set('cancelAction.loading', true);
     assert.dom(`${secondaryBtn} .Polaris-Button__Spinner`).exists();
   });
+
+  /************************************\
+  | Tests for internal customisations. |
+  \************************************/
+  test('it renders card sections in a horizontal row when rowSections is truthy', async function (assert) {
+    await render(hbs`
+      <PolarisCard @rowSections={{true}} as |card|>
+        <card.section @title="Section 1" @text="Section 1 content" />
+        <card.section @text="Section 2 content" />
+      </PolarisCard>
+    `);
+
+    assert.dom(sectionSelector).exists({ count: 2 });
+
+    let sections = findAll(sectionSelector);
+    let [section1Rect, section2Rect] = sections.map((section) => {
+      return section.getBoundingClientRect();
+    });
+
+    assert.equal(section1Rect.top, section2Rect.top);
+    assert.equal(section1Rect.right, section2Rect.left);
+
+    let section2Style = getComputedStyle(sections[1]);
+    assert.ok(section2Style.borderTop.match(/^0px.*/));
+    assert.ok(section2Style.borderLeft.match(/^1px.*/));
+  });
 });

--- a/tests/integration/components/polaris-card-test.js
+++ b/tests/integration/components/polaris-card-test.js
@@ -473,9 +473,9 @@ module('Integration | Component | polaris card', function (hooks) {
   /************************************\
   | Tests for internal customisations. |
   \************************************/
-  test('it renders card sections in a horizontal row when rowSections is truthy', async function (assert) {
+  test('it renders card sections in a horizontal row when sectionDirection is set to "row"', async function (assert) {
     await render(hbs`
-      <PolarisCard @rowSections={{true}} as |card|>
+      <PolarisCard @sectionDirection="row" as |card|>
         <card.section @title="Section 1" @text="Section 1 content" />
         <card.section @text="Section 2 content" />
       </PolarisCard>


### PR DESCRIPTION
I had a design come through which needed a card with what look like sections arranged in a horizontal row instead of the default vertical column, and figured that it was worth making the functionality reusable 🤷‍♂️ 

![image](https://user-images.githubusercontent.com/5737342/92584555-729e0500-f29c-11ea-92bf-36f8db0d32b6.png)
