### PR TITLE
Fix sticky manager

### DIFF
--- a/.lint-todo
+++ b/.lint-todo
@@ -1233,3 +1233,6 @@ add|ember-template-lint|no-action|481|34|481|34|bfda11268adacee3d85d949191eaef65
 add|ember-template-lint|no-curly-component-invocation|478|14|478|14|288855346142f21a93fc97d3cc3f023dc64d6fc0|1694649600000|||tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
 add|ember-template-lint|no-positive-tabindex|2|2|2|2|fc0a48a2c236b462e7fe5ce61af2a0ca6c0bdd55|1695686400000|||addon/templates/components/polaris-date-picker/day.hbs
 add|ember-template-lint|no-invalid-interactive|1|31|1|31|a4df5ba56d33be2595fe0bdc113132ad98e56881|1695686400000|||addon/templates/components/polaris-resource-list/checkable-button.hbs
+remove|ember-template-lint|no-action|374|21|374|21|debe11c57b2ab117d783bd2ea2a7762ecf6bc9c7|1694649600000|||tests/integration/components/polaris-text-field-test.js
+remove|ember-template-lint|no-curly-component-invocation|370|10|370|10|9dcefee0de75e6b8dc85113edf8049e63f41a166|1694649600000|||tests/integration/components/polaris-text-field-test.js
+add|ember-template-lint|no-curly-component-invocation|368|10|368|10|949cd6da9faa8f412724adb81a9814bf7b31bc1a|1695859200000|||tests/integration/components/polaris-text-field-test.js

--- a/addon/services/sticky-manager.js
+++ b/addon/services/sticky-manager.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import { action } from '@ember/object';
 import { throttleTask, runDisposables } from 'ember-lifeline';
 import tokens from '@shopify/polaris-tokens';
 import { getRectForNode } from '@shopify/javascript-utilities/geometry';
@@ -46,10 +47,12 @@ export default class StickyManager extends Service {
     }
   }
 
+  @action
   handleResize() {
     throttleTask(this, 'manageStickyItems', 40, false);
   }
 
+  @action
   handleScroll() {
     throttleTask(this, 'manageStickyItems', 40, false);
   }

--- a/tests/integration/components/polaris-text-field-test.js
+++ b/tests/integration/components/polaris-text-field-test.js
@@ -9,6 +9,7 @@ import {
   blur,
   click,
 } from '@ember/test-helpers';
+import { action } from '@ember/object';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 const label = 'Text field label';
@@ -356,22 +357,20 @@ module('Integration | Component | polaris-text-field', function (hooks) {
 
     module('when type is number', function () {
       test('it handles incrementing/decrementing correctly', async function (assert) {
-        this.setProperties({
-          value: 1,
-          id: 'myId',
-          disabled: false,
-          handleChange(num, id) {
-            this.set('value', num);
-            assert.ok(id, this.id);
-          },
-        });
+        this.handleChange = (num, id) => {
+          this.set('value', num);
+          assert.ok(id, this.id);
+        };
+        this.value = 1;
+        this.id = 'myId';
+        this.disabled = false;
 
         await render(hbs`
           {{polaris-text-field
             type="number"
             value=value
             disabled=disabled
-            onChange=(action handleChange)
+            onChange=this.handleChange
           }}
         `);
 

--- a/tests/integration/components/polaris-text-field-test.js
+++ b/tests/integration/components/polaris-text-field-test.js
@@ -9,7 +9,6 @@ import {
   blur,
   click,
 } from '@ember/test-helpers';
-import { action } from '@ember/object';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 const label = 'Text field label';


### PR DESCRIPTION
Fixes an issue with our `sticky-manager` services. Found while testing in our apps.
<img width="1122" alt="Screenshot 2023-09-28 at 15 03 56" src="https://github.com/smile-io/ember-smile-polaris/assets/160955/c47540b4-7dc5-4e73-937c-fac701e716b1">

Also, tweaks a test that seemed to fail randomly.