### PR TITLE
Fix svg jar config

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@ module.exports = {
   name: require('./package').name,
 
   options: {
+    svgJar: {
+      inline: {
+        // This overwrites default glocal `sourceDirs: []` since we don't want that.
+        sourceDirs: [],
+      },
+    },
+
     'ember-composable-helpers': {
       only: ['includes'],
     },

--- a/index.js
+++ b/index.js
@@ -4,13 +4,6 @@ module.exports = {
   name: require('./package').name,
 
   options: {
-    svgJar: {
-      sourceDirs: [
-        'public',
-        'tests/dummy/public/assets/images/svg',
-        'node_modules/@smile-io/ember-smile-polaris/public',
-      ],
-    },
     'ember-composable-helpers': {
       only: ['includes'],
     },


### PR DESCRIPTION
Apps are responsible for making Polaris icons available, so we didn't need this config. Just keeping it to overwrite the main default which is to include addon's `public` folder. We don't need that either.

**NOTE** This is needed because it ended up having `ember-svg-jar` to include unneeded all SVG's into the bundle from the app's `public` folder.