### PR TITLE
update ember-basic-dropdown pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "broccoli-merge-trees": "^4.2.0",
     "chalk": "^4.0.0",
     "ember-auto-import": "^2.6.3",
-    "ember-basic-dropdown": "^6.0.2",
+    "ember-basic-dropdown": "^7.3.0",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ dependencies:
     specifier: ^2.6.3
     version: 2.7.1(webpack@5.89.0)
   ember-basic-dropdown:
-    specifier: ^6.0.2
-    version: 6.0.2(@babel/core@7.23.7)(ember-source@3.28.12)
+    specifier: ^7.3.0
+    version: 7.3.0(@babel/core@7.23.7)(ember-source@3.28.12)(webpack@5.89.0)
   ember-cli-babel:
     specifier: ^7.26.10
     version: 7.26.11
@@ -3754,9 +3754,6 @@ packages:
       {
         integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==,
       }
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
     dev: false
@@ -7959,33 +7956,36 @@ packages:
       - webpack
     dev: false
 
-  /ember-basic-dropdown@6.0.2(@babel/core@7.23.7)(ember-source@3.28.12):
+  /ember-basic-dropdown@7.3.0(@babel/core@7.23.7)(ember-source@3.28.12)(webpack@5.89.0):
     resolution:
       {
-        integrity: sha512-JgI/cy7eS/Y2WoQl7B2Mko/1aFTAlxr5d+KpQeH7rBKOFml7IQtLvhiDQrpU/FLkrQ9aLNEJtzwtDZV1xQxAKA==,
+        integrity: sha512-XzLd1noCrHjG7O35HpZ+ljj7VwPPqon7svbvNJ2U7421e00eXBUVcCioGJFo1NnnPkjc14FTDc5UwktbGSbJdQ==,
       }
-    engines: { node: 12.* || 14.* || >= 16 }
+    engines: { node: 16.* || >= 18 }
+    peerDependencies:
+      ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
     dependencies:
-      "@ember/render-modifiers": 2.1.0(@babel/core@7.23.7)(ember-source@3.28.12)
       "@embroider/macros": 1.13.4
       "@embroider/util": 1.12.1(ember-source@3.28.12)
       "@glimmer/component": 1.1.2(@babel/core@7.23.7)
       "@glimmer/tracking": 1.1.2
+      ember-auto-import: 2.7.1(webpack@5.89.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-cli-typescript: 4.2.1
-      ember-element-helper: 0.6.1(ember-source@3.28.12)
+      ember-cli-typescript: 5.2.1
+      ember-element-helper: 0.8.5(ember-source@3.28.12)
       ember-get-config: 2.1.1
       ember-maybe-in-element: 2.1.0
-      ember-modifier: 3.2.7(@babel/core@7.23.7)
+      ember-modifier: 4.1.0(ember-source@3.28.12)
+      ember-source: 3.28.12(@babel/core@7.23.7)
       ember-style-modifier: 1.0.0(@babel/core@7.23.7)
-      ember-truth-helpers: 3.1.1
+      ember-truth-helpers: 4.0.3(ember-source@3.28.12)
     transitivePeerDependencies:
       - "@babel/core"
       - "@glint/environment-ember-loose"
       - "@glint/template"
-      - ember-source
       - supports-color
+      - webpack
     dev: false
 
   /ember-cli-babel-plugin-helpers@1.1.1:
@@ -8331,27 +8331,6 @@ packages:
       - supports-color
     dev: false
 
-  /ember-cli-typescript@4.2.1:
-    resolution:
-      {
-        integrity: sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==,
-      }
-    engines: { node: 10.* || >= 12.* }
-    dependencies:
-      ansi-to-html: 0.6.15
-      broccoli-stew: 3.0.0
-      debug: 4.3.4
-      execa: 4.1.0
-      fs-extra: 9.1.0
-      resolve: 1.22.8
-      rsvp: 4.8.5
-      semver: 7.5.4
-      stagehand: 1.0.1
-      walk-sync: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /ember-cli-typescript@5.2.1:
     resolution:
       {
@@ -8645,25 +8624,6 @@ packages:
       }
     engines: { node: ">= 0.10.0" }
     dev: true
-
-  /ember-element-helper@0.6.1(ember-source@3.28.12):
-    resolution:
-      {
-        integrity: sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==,
-      }
-    engines: { node: 12.* || 14.* || >= 16 }
-    peerDependencies:
-      ember-source: ^3.8 || 4
-    dependencies:
-      "@embroider/util": 1.12.1(ember-source@3.28.12)
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-source: 3.28.12(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - "@glint/environment-ember-loose"
-      - "@glint/template"
-      - supports-color
-    dev: false
 
   /ember-element-helper@0.8.5(ember-source@3.28.12):
     resolution:
@@ -9118,18 +9078,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /ember-truth-helpers@3.1.1:
-    resolution:
-      {
-        integrity: sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==,
-      }
-    engines: { node: 10.* || >= 12 }
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /ember-truth-helpers@4.0.3(ember-source@3.28.12):
     resolution:
@@ -14982,6 +14930,7 @@ packages:
         integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==,
       }
     engines: { node: ">=0.10.0" }
+    requiresBuild: true
     dependencies:
       remove-trailing-separator: 1.1.0
     dev: true
@@ -16959,6 +16908,7 @@ packages:
       {
         integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==,
       }
+    requiresBuild: true
     dev: true
 
   /repeat-element@1.1.4:


### PR DESCRIPTION
This PR is updating the `ember-basic-dropdown` pkg to version 7.3.0.  

The reason for this change is that we are trying to merge a PR to update `ember-assign-helper` on smile-admin ([ref](https://github.com/smile-io/smile-admin/pull/6109)), which is requiring a `ember-power-select` update as well, otherwise this error is happening:
`ember-power-select needs to depend on ember-auto-import in order to use ember-assign-helper
`