### PR TITLE
Address changes needed for Ember 4

### DIFF
--- a/addon/components/polaris-banner.js
+++ b/addon/components/polaris-banner.js
@@ -198,7 +198,9 @@ export default class PolarisBanner extends Component {
       !this.action,
       {
         id: 'ember-polaris.polaris-banner.action-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-connected.js
+++ b/addon/components/polaris-connected.js
@@ -46,7 +46,9 @@ export default class PolarisConnected extends Component {
       this.dataTestConnected === true,
       {
         id: 'ember-polaris.polaris-connected.dataTestConnected-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
     this.dataTestConnected = this.dataTestConnected || true;

--- a/addon/components/polaris-display-text.js
+++ b/addon/components/polaris-display-text.js
@@ -64,7 +64,9 @@ export default class PolarisDisplayText extends Component {
       !this.tagName,
       {
         id: 'ember-polaris.polaris-display-text.tagName-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-empty-state.js
+++ b/addon/components/polaris-empty-state.js
@@ -85,7 +85,9 @@ export default class PolarisEmptyState extends Component {
       !this.action,
       {
         id: 'ember-polaris.polaris-empty-state.action-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-heading.js
+++ b/addon/components/polaris-heading.js
@@ -53,7 +53,9 @@ export default class PolarisHeading extends Component {
       !this.tagName,
       {
         id: 'ember-polaris.polaris-heading.tagName-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -110,7 +110,9 @@ export default class PolarisLabelled extends Component {
       !this.action,
       {
         id: 'ember-polaris.polaris-labelled.action-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
     deprecate(
@@ -118,7 +120,9 @@ export default class PolarisLabelled extends Component {
       this.dataTestLabelled === true,
       {
         id: 'ember-polaris.polaris-labelled.dataTestLabelled-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
     this.dataTestLabelled = this.dataTestLabelled || true;

--- a/addon/components/polaris-setting-toggle.js
+++ b/addon/components/polaris-setting-toggle.js
@@ -52,7 +52,9 @@ export default class PolarisSettingToggle extends Component {
       !this.action,
       {
         id: 'ember-polaris.polaris-seting-toggle.action-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -520,7 +520,9 @@ export default class PolarisTextField extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-text-field.dataTestTextField-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-text-style.js
+++ b/addon/components/polaris-text-style.js
@@ -90,7 +90,9 @@ export default class PolarisTextStyle extends Component {
       !this.classes,
       {
         id: 'ember-polaris.polaris-text-style.classes-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
     deprecate(
@@ -98,7 +100,9 @@ export default class PolarisTextStyle extends Component {
       !this.dataTestTextStyle,
       {
         id: 'ember-polaris.polaris-text-style.dataTestTextStyle-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -125,7 +125,9 @@ export default class PolarisUnstyledLink extends Component {
       !this.dataTestId,
       {
         id: 'ember-polaris.polaris-unstyled-link.dataTestId-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
     deprecate(
@@ -133,7 +135,9 @@ export default class PolarisUnstyledLink extends Component {
       !this.dataPolarisUnstyled,
       {
         id: 'ember-polaris.polaris-unstyled-link.dataPolarisUnstyled-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
     deprecate(
@@ -141,7 +145,9 @@ export default class PolarisUnstyledLink extends Component {
       !this.id,
       {
         id: 'ember-polaris.polaris-unstyled-link.id-arg',
+        since: '6.2.2',
         until: '7.0.0',
+        for: 'ember-polaris',
       },
     );
   }

--- a/addon/utils/deprecate-class-argument.js
+++ b/addon/utils/deprecate-class-argument.js
@@ -13,7 +13,9 @@ export default function deprecateClassArgument(target) {
           !this.class,
           {
             id: `ember-polaris.${dasherize(componentName)}.class-arg`,
+            since: '6.2.2',
             until: '7.0.0',
+            for: 'ember-polaris',
           },
         );
 


### PR DESCRIPTION
This PR addresses issues found during the update of `smile-admin` to Ember 4. 

UPDATE: After playing around for some time, the `deprecate` issue is the only issue I could find