### PR TITLE
AS-407 Ember 4 change | Refactor ariaInvalid property

### DIFF
--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
-import { bool } from '@ember/object/computed';
 import { guidFor } from '@ember/object/internals';
 import { htmlSafe } from '@ember/template';
 import { typeOf, isPresent } from '@ember/utils';
@@ -356,8 +355,14 @@ export default class PolarisTextField extends Component {
   wasFocused = false;
   dataTestTextField = 'text-field';
 
-  @bool('error')
-  ariaInvalid;
+  @computed('error', '_ariaInvalid')
+  get ariaInvalid() {
+    return this._ariaInvalid ?? !!this.error;
+  }
+
+  set ariaInvalid(value) {
+    this.set('_ariaInvalid', value);
+  }
 
   @normalizeAutoCompleteProperty('autoComplete')
   autoCompleteInputs;


### PR DESCRIPTION
There are instances where we set `ariaInvalid`. For example:

```hbs
<PolarisTextField
  @ariaInvalid={{this.someMethod}}
/>
```

However, since it is a boolean computed property, we cannot use this approach in Ember 4 anymore. This PR solves this issue by adding a getter and a setter for `ariaInvalid`.

