### PR TITLE
Fix PolarisTextField multiline same computation error

### DIFF
--- a/addon/components/polaris-text-field/resizer.js
+++ b/addon/components/polaris-text-field/resizer.js
@@ -4,6 +4,7 @@ import { htmlSafe } from '@ember/template';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-text-field/resizer';
 import deprecateClassArgument from '../../utils/deprecate-class-argument';
+import { scheduleOnce } from '@ember/runloop';
 
 const REPLACE_REGEX = /[\n&<>]/g;
 
@@ -93,7 +94,7 @@ export default class PolarisTextFieldResizer extends Component {
     let { currentHeight, onHeightChange } = this;
 
     if (newHeight !== currentHeight) {
-      onHeightChange(newHeight);
+      scheduleOnce('afterRender', this, onHeightChange, newHeight);
     }
   }
 


### PR DESCRIPTION
Fixes this error under optimized embroider when using `PolarisTextField` with `multiline` 

<img width="1767" alt="Screenshot 2024-03-14 at 14 50 29" src="https://github.com/smile-io/ember-smile-polaris/assets/160955/487c0ae5-be83-4182-a5e1-4dd5debf25b1">
