### PR TITLE
AS-452 use Object.assign instead of ember assign

### DIFF
--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -3,7 +3,6 @@ import { action, computed } from '@ember/object';
 import { isBlank, isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 import { scheduleOnce } from '@ember/runloop';
-import { assign } from '@ember/polyfills';
 import { isEqual } from '@ember/utils';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
@@ -256,7 +255,7 @@ export default class PolarisDataTable extends Component.extend(
 
       let lastColumn = columnVisibilityData[columnVisibilityData.length - 1];
 
-      return assign(
+      return Object.assign(
         {
           fixedColumnWidth,
           columnVisibilityData,
@@ -291,7 +290,7 @@ export default class PolarisDataTable extends Component.extend(
     }
 
     this.setProperties(
-      assign(
+      Object.assign(
         {
           collapsed,
           heights: [],

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -4,7 +4,6 @@ import { guidFor } from '@ember/object/internals';
 import { htmlSafe } from '@ember/template';
 import { dasherize } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
-import { assign } from '@ember/polyfills';
 import { errorId, helpTextId } from '@smile-io/ember-smile-polaris/utils/id';
 import layout from '../templates/components/polaris-range-slider';
 
@@ -210,7 +209,7 @@ export default class PolarisRangeSlider extends Component {
   get rangeWrapperStyle() {
     let { min, max, value: current, sliderProgress } = this;
 
-    let styleProps = assign(
+    let styleProps = Object.assign(
       { min, max, current },
       {
         progress: `${sliderProgress}%`,


### PR DESCRIPTION
In order to be able to upgrade smile-internal to Ember 5 we need to use the native Object.assign method instead of the Ember implementation