### PR TITLE
Upgrading ember-basic-dropdown and ember/string

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@ember-decorators/component": "^6.0.1",
     "@ember/render-modifiers": "^2.1.0",
-    "@ember/string": "^3.1.1",
+    "@ember/string": "^4.0.0",
     "@shopify/javascript-utilities": "^2.4.0",
     "@shopify/polaris": "3.10.0",
     "@shopify/polaris-tokens": "^1.3.1",
@@ -63,7 +63,7 @@
     "broccoli-merge-trees": "^4.2.0",
     "chalk": "^4.0.0",
     "ember-auto-import": "^2.6.3",
-    "ember-basic-dropdown": "^7.3.0",
+    "ember-basic-dropdown": "^8.4.0",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^2.1.0
     version: 2.1.0(@babel/core@7.23.7)(ember-source@3.28.12)
   "@ember/string":
-    specifier: ^3.1.1
-    version: 3.1.1
+    specifier: ^4.0.0
+    version: 4.0.0
   "@shopify/javascript-utilities":
     specifier: ^2.4.0
     version: 2.4.1
@@ -39,8 +39,8 @@ dependencies:
     specifier: ^2.6.3
     version: 2.7.1(webpack@5.89.0)
   ember-basic-dropdown:
-    specifier: ^7.3.0
-    version: 7.3.0(@babel/core@7.23.7)(ember-source@3.28.12)(webpack@5.89.0)
+    specifier: ^8.4.0
+    version: 8.4.0(@ember/string@4.0.0)(@ember/test-helpers@2.9.4)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-source@3.28.12)
   ember-cli-babel:
     specifier: ^7.26.10
     version: 7.26.11
@@ -259,12 +259,32 @@ packages:
       "@babel/highlight": 7.23.4
       chalk: 2.4.2
 
+  /@babel/code-frame@7.26.2:
+    resolution:
+      {
+        integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/helper-validator-identifier": 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.0.0
+    dev: false
+
   /@babel/compat-data@7.23.5:
     resolution:
       {
         integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==,
       }
     engines: { node: ">=6.9.0" }
+
+  /@babel/compat-data@7.26.2:
+    resolution:
+      {
+        integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==,
+      }
+    engines: { node: ">=6.9.0" }
+    dev: false
 
   /@babel/core@7.23.7:
     resolution:
@@ -290,6 +310,32 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/core@7.26.0:
+    resolution:
+      {
+        integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@ampproject/remapping": 2.2.1
+      "@babel/code-frame": 7.26.2
+      "@babel/generator": 7.26.2
+      "@babel/helper-compilation-targets": 7.25.9
+      "@babel/helper-module-transforms": 7.26.0(@babel/core@7.26.0)
+      "@babel/helpers": 7.26.0
+      "@babel/parser": 7.26.2
+      "@babel/template": 7.25.9
+      "@babel/traverse": 7.25.9
+      "@babel/types": 7.26.0
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/eslint-parser@7.23.3(@babel/core@7.23.7)(eslint@8.56.0):
     resolution:
@@ -319,6 +365,20 @@ packages:
       "@jridgewell/gen-mapping": 0.3.3
       "@jridgewell/trace-mapping": 0.3.20
       jsesc: 2.5.2
+
+  /@babel/generator@7.26.2:
+    resolution:
+      {
+        integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/parser": 7.26.2
+      "@babel/types": 7.26.0
+      "@jridgewell/gen-mapping": 0.3.5
+      "@jridgewell/trace-mapping": 0.3.25
+      jsesc: 3.0.2
+    dev: false
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution:
@@ -350,6 +410,20 @@ packages:
       browserslist: 4.22.2
       lru-cache: 5.1.1
       semver: 6.3.1
+
+  /@babel/helper-compilation-targets@7.25.9:
+    resolution:
+      {
+        integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/compat-data": 7.26.2
+      "@babel/helper-validator-option": 7.25.9
+      browserslist: 4.24.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: false
 
   /@babel/helper-create-class-features-plugin@7.23.6(@babel/core@7.23.7):
     resolution:
@@ -446,6 +520,19 @@ packages:
     dependencies:
       "@babel/types": 7.23.6
 
+  /@babel/helper-module-imports@7.25.9:
+    resolution:
+      {
+        integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/traverse": 7.25.9
+      "@babel/types": 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.7):
     resolution:
       {
@@ -461,6 +548,23 @@ packages:
       "@babel/helper-simple-access": 7.22.5
       "@babel/helper-split-export-declaration": 7.22.6
       "@babel/helper-validator-identifier": 7.22.20
+
+  /@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0):
+    resolution:
+      {
+        integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+    dependencies:
+      "@babel/core": 7.26.0
+      "@babel/helper-module-imports": 7.25.9
+      "@babel/helper-validator-identifier": 7.25.9
+      "@babel/traverse": 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution:
@@ -540,6 +644,14 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  /@babel/helper-string-parser@7.25.9:
+    resolution:
+      {
+        integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==,
+      }
+    engines: { node: ">=6.9.0" }
+    dev: false
+
   /@babel/helper-validator-identifier@7.22.20:
     resolution:
       {
@@ -547,12 +659,28 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  /@babel/helper-validator-identifier@7.25.9:
+    resolution:
+      {
+        integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    dev: false
+
   /@babel/helper-validator-option@7.23.5:
     resolution:
       {
         integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==,
       }
     engines: { node: ">=6.9.0" }
+
+  /@babel/helper-validator-option@7.25.9:
+    resolution:
+      {
+        integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==,
+      }
+    engines: { node: ">=6.9.0" }
+    dev: false
 
   /@babel/helper-wrap-function@7.22.20:
     resolution:
@@ -578,6 +706,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helpers@7.26.0:
+    resolution:
+      {
+        integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/template": 7.25.9
+      "@babel/types": 7.26.0
+    dev: false
+
   /@babel/highlight@7.23.4:
     resolution:
       {
@@ -598,6 +737,17 @@ packages:
     hasBin: true
     dependencies:
       "@babel/types": 7.23.6
+
+  /@babel/parser@7.26.2:
+    resolution:
+      {
+        integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+    dependencies:
+      "@babel/types": 7.26.0
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.7):
     resolution:
@@ -786,6 +936,19 @@ packages:
     dependencies:
       "@babel/core": 7.23.7
       "@babel/helper-plugin-utils": 7.22.5
+
+  /@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.26.0):
+    resolution:
+      {
+        integrity: sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.26.0
+      "@babel/helper-plugin-utils": 7.22.5
+    dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.7):
     resolution:
@@ -1835,6 +1998,18 @@ packages:
       "@babel/parser": 7.23.6
       "@babel/types": 7.23.6
 
+  /@babel/template@7.25.9:
+    resolution:
+      {
+        integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/code-frame": 7.26.2
+      "@babel/parser": 7.26.2
+      "@babel/types": 7.26.0
+    dev: false
+
   /@babel/traverse@7.23.6:
     resolution:
       {
@@ -1876,6 +2051,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/traverse@7.25.9:
+    resolution:
+      {
+        integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/code-frame": 7.26.2
+      "@babel/generator": 7.26.2
+      "@babel/parser": 7.26.2
+      "@babel/template": 7.25.9
+      "@babel/types": 7.26.0
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/types@7.23.6:
     resolution:
       {
@@ -1886,6 +2079,17 @@ packages:
       "@babel/helper-string-parser": 7.23.4
       "@babel/helper-validator-identifier": 7.22.20
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.26.0:
+    resolution:
+      {
+        integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      "@babel/helper-string-parser": 7.25.9
+      "@babel/helper-validator-identifier": 7.25.9
+    dev: false
 
   /@cnakazawa/watch@1.0.4:
     resolution:
@@ -1998,16 +2202,11 @@ packages:
       - supports-color
     dev: false
 
-  /@ember/string@3.1.1:
+  /@ember/string@4.0.0:
     resolution:
       {
-        integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==,
+        integrity: sha512-IMVyVE72twuAMSYcHzWSgtgYTtzlHlKSGW8vEbztnnmkU6uo7kVHmiqSN9R4RkBhzvh0VD4G76Eph+55t3iNIA==,
       }
-    engines: { node: 12.* || 14.* || >= 16 }
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@ember/test-helpers@2.9.4(@babel/core@7.23.7)(ember-source@3.28.12):
@@ -2072,6 +2271,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@embroider/addon-shim@1.9.0:
+    resolution:
+      {
+        integrity: sha512-fMzayl/licUL8VRAy4qXROKcYvHwUbV8aTh4m97L5/MRuVpxbcAy92DGGTqx5OBKCSQN3gMg+sUKeE6AviefpQ==,
+      }
+    engines: { node: 12.* || 14.* || >= 16 }
+    dependencies:
+      "@embroider/shared-internals": 2.8.1
+      broccoli-funnel: 3.0.8
+      common-ancestor-path: 1.0.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@embroider/macros@1.13.4:
     resolution:
       {
@@ -2094,6 +2308,30 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
+
+  /@embroider/macros@1.16.9:
+    resolution:
+      {
+        integrity: sha512-AUrmHQdixczIU3ouv/+HzWxwYVsw/NwssZxAQnXfBDJ3d3/CRtAvGRu3JhY6OT3AAPFwfa2WT66tB5jeAa7r5g==,
+      }
+    engines: { node: 12.* || 14.* || >= 16 }
+    peerDependencies:
+      "@glint/template": ^1.0.0
+    peerDependenciesMeta:
+      "@glint/template":
+        optional: true
+    dependencies:
+      "@embroider/shared-internals": 2.8.1
+      assert-never: 1.2.1
+      babel-import-util: 2.0.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.8
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@embroider/shared-internals@1.8.3:
     resolution:
@@ -2130,6 +2368,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@embroider/shared-internals@2.8.1:
+    resolution:
+      {
+        integrity: sha512-zi0CENFD1e0DH7c9M/rNKJnFnt2c3+736J3lguBddZdmaIV6Cb8l3HQSkskSW5O4ady+SavemLKO3hCjQQJBIw==,
+      }
+    engines: { node: 12.* || 14.* || >= 16 }
+    dependencies:
+      babel-import-util: 2.0.1
+      debug: 4.3.4
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.5.4
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@embroider/test-setup@0.48.1:
     resolution:
       {
@@ -2163,6 +2424,30 @@ packages:
       ember-source: 3.28.12(@babel/core@7.23.7)
     transitivePeerDependencies:
       - supports-color
+
+  /@embroider/util@1.13.2(ember-source@3.28.12):
+    resolution:
+      {
+        integrity: sha512-6/0sK4dtFK7Ld+t5Ovn9EilBVySoysMRdDAf/jGteOO7jdLKNgHnONg0w1T7ZZaMFUQfwJdRrk3u0dM+Idhiew==,
+      }
+    engines: { node: 12.* || 14.* || >= 16 }
+    peerDependencies:
+      "@glint/environment-ember-loose": ^1.0.0
+      "@glint/template": ^1.0.0
+      ember-source: "*"
+    peerDependenciesMeta:
+      "@glint/environment-ember-loose":
+        optional: true
+      "@glint/template":
+        optional: true
+    dependencies:
+      "@embroider/macros": 1.16.9
+      broccoli-funnel: 3.0.8
+      ember-cli-babel: 7.26.11
+      ember-source: 3.28.12(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.56.0):
     resolution:
@@ -2402,6 +2687,18 @@ packages:
       "@jridgewell/sourcemap-codec": 1.4.15
       "@jridgewell/trace-mapping": 0.3.20
 
+  /@jridgewell/gen-mapping@0.3.5:
+    resolution:
+      {
+        integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==,
+      }
+    engines: { node: ">=6.0.0" }
+    dependencies:
+      "@jridgewell/set-array": 1.2.1
+      "@jridgewell/sourcemap-codec": 1.4.15
+      "@jridgewell/trace-mapping": 0.3.25
+    dev: false
+
   /@jridgewell/resolve-uri@3.1.1:
     resolution:
       {
@@ -2415,6 +2712,14 @@ packages:
         integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==,
       }
     engines: { node: ">=6.0.0" }
+
+  /@jridgewell/set-array@1.2.1:
+    resolution:
+      {
+        integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==,
+      }
+    engines: { node: ">=6.0.0" }
+    dev: false
 
   /@jridgewell/source-map@0.3.5:
     resolution:
@@ -2439,6 +2744,16 @@ packages:
     dependencies:
       "@jridgewell/resolve-uri": 3.1.1
       "@jridgewell/sourcemap-codec": 1.4.15
+
+  /@jridgewell/trace-mapping@0.3.25:
+    resolution:
+      {
+        integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==,
+      }
+    dependencies:
+      "@jridgewell/resolve-uri": 3.1.1
+      "@jridgewell/sourcemap-codec": 1.4.15
+    dev: false
 
   /@lint-todo/utils@13.1.1:
     resolution:
@@ -3754,6 +4069,9 @@ packages:
       {
         integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==,
       }
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.12.0
     dev: false
@@ -4397,6 +4715,14 @@ packages:
       }
     engines: { node: ">= 12.*" }
 
+  /babel-import-util@3.0.0:
+    resolution:
+      {
+        integrity: sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==,
+      }
+    engines: { node: ">= 12.*" }
+    dev: false
+
   /babel-loader@8.3.0(@babel/core@7.23.7)(webpack@4.47.0):
     resolution:
       {
@@ -4743,6 +5069,16 @@ packages:
         integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==,
       }
     dev: true
+
+  /better-path-resolve@1.0.0:
+    resolution:
+      {
+        integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==,
+      }
+    engines: { node: ">=4" }
+    dependencies:
+      is-windows: 1.0.2
+    dev: false
 
   /big-integer@1.6.52:
     resolution:
@@ -5722,6 +6058,20 @@ packages:
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
 
+  /browserslist@4.24.2:
+    resolution:
+      {
+        integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001683
+      electron-to-chromium: 1.5.63
+      node-releases: 2.0.18
+      update-browserslist-db: 1.1.1(browserslist@4.24.2)
+    dev: false
+
   /bser@2.1.1:
     resolution:
       {
@@ -5998,6 +6348,13 @@ packages:
       {
         integrity: sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==,
       }
+
+  /caniuse-lite@1.0.30001683:
+    resolution:
+      {
+        integrity: sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==,
+      }
+    dev: false
 
   /capture-exit@2.0.0:
     resolution:
@@ -6561,6 +6918,13 @@ packages:
       }
     engines: { node: ">= 12" }
     dev: true
+
+  /common-ancestor-path@1.0.1:
+    resolution:
+      {
+        integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+      }
+    dev: false
 
   /common-tags@1.8.2:
     resolution:
@@ -7406,6 +7770,18 @@ packages:
       mimic-response: 3.1.0
     dev: true
 
+  /decorator-transforms@2.3.0(@babel/core@7.26.0):
+    resolution:
+      {
+        integrity: sha512-jo8c1ss9yFPudHuYYcrJ9jpkDZIoi+lOGvt+Uyp9B+dz32i50icRMx9Bfa8hEt7TnX1FyKWKkjV+cUdT/ep2kA==,
+      }
+    dependencies:
+      "@babel/plugin-syntax-decorators": 7.23.3(@babel/core@7.26.0)
+      babel-import-util: 3.0.0
+    transitivePeerDependencies:
+      - "@babel/core"
+    dev: false
+
   /deep-extend@0.6.0:
     resolution:
       {
@@ -7839,6 +8215,13 @@ packages:
         integrity: sha512-/bKPPcgZVUziECqDc+0HkT87+0zhaWSZHNXqF8FLd2lQcptpmUFwoCSWjCdOng9Gdq+afKArPdEg/0ZW461Eng==,
       }
 
+  /electron-to-chromium@1.5.63:
+    resolution:
+      {
+        integrity: sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==,
+      }
+    dev: false
+
   /elliptic@6.5.4:
     resolution:
       {
@@ -7956,36 +8339,36 @@ packages:
       - webpack
     dev: false
 
-  /ember-basic-dropdown@7.3.0(@babel/core@7.23.7)(ember-source@3.28.12)(webpack@5.89.0):
+  /ember-basic-dropdown@8.4.0(@ember/string@4.0.0)(@ember/test-helpers@2.9.4)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-source@3.28.12):
     resolution:
       {
-        integrity: sha512-XzLd1noCrHjG7O35HpZ+ljj7VwPPqon7svbvNJ2U7421e00eXBUVcCioGJFo1NnnPkjc14FTDc5UwktbGSbJdQ==,
+        integrity: sha512-vaK0ypA6J8hduvIrctquMpIoAsgp1Uz/W2RGQJ1KsvvgAttowuDBBuGFEmubzhnnKJM2LGBX7+miRXnn36kBTA==,
       }
-    engines: { node: 16.* || >= 18 }
     peerDependencies:
+      "@ember/test-helpers": ^2.9.4 || ^3.2.1 || ^4.0.2
+      "@glimmer/component": ^1.1.2 || ^2.0.0
+      "@glimmer/tracking": ^1.1.2
       ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
     dependencies:
-      "@embroider/macros": 1.13.4
-      "@embroider/util": 1.12.1(ember-source@3.28.12)
+      "@babel/core": 7.26.0
+      "@ember/test-helpers": 2.9.4(@babel/core@7.23.7)(ember-source@3.28.12)
+      "@embroider/addon-shim": 1.9.0
+      "@embroider/macros": 1.16.9
+      "@embroider/util": 1.13.2(ember-source@3.28.12)
       "@glimmer/component": 1.1.2(@babel/core@7.23.7)
       "@glimmer/tracking": 1.1.2
-      ember-auto-import: 2.7.1(webpack@5.89.0)
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-cli-typescript: 5.2.1
-      ember-element-helper: 0.8.5(ember-source@3.28.12)
-      ember-get-config: 2.1.1
-      ember-maybe-in-element: 2.1.0
-      ember-modifier: 4.1.0(ember-source@3.28.12)
+      decorator-transforms: 2.3.0(@babel/core@7.26.0)
+      ember-element-helper: 0.8.6(ember-source@3.28.12)
+      ember-lifeline: 7.0.0(@ember/test-helpers@2.9.4)
+      ember-modifier: 4.2.0(@babel/core@7.26.0)(ember-source@3.28.12)
       ember-source: 3.28.12(@babel/core@7.23.7)
-      ember-style-modifier: 1.0.0(@babel/core@7.23.7)
+      ember-style-modifier: 4.4.0(@babel/core@7.26.0)(@ember/string@4.0.0)(ember-source@3.28.12)
       ember-truth-helpers: 4.0.3(ember-source@3.28.12)
     transitivePeerDependencies:
-      - "@babel/core"
+      - "@ember/string"
       - "@glint/environment-ember-loose"
       - "@glint/template"
       - supports-color
-      - webpack
     dev: false
 
   /ember-cli-babel-plugin-helpers@1.1.1:
@@ -8643,6 +9026,24 @@ packages:
       - supports-color
     dev: false
 
+  /ember-element-helper@0.8.6(ember-source@3.28.12):
+    resolution:
+      {
+        integrity: sha512-WcbkJKgBZypRGwujeiPrQfZRhETVFLR0wvH2UxDaNBhLWncapt6KK+M/2i/eODoAQwgGxziejhXC6Cbqa9zA8g==,
+      }
+    engines: { node: 14.* || 16.* || >= 18 }
+    peerDependencies:
+      ember-source: ^3.8 || ^4.0.0 || >= 5.0.0
+    dependencies:
+      "@embroider/addon-shim": 1.9.0
+      "@embroider/util": 1.12.1(ember-source@3.28.12)
+      ember-source: 3.28.12(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - "@glint/environment-ember-loose"
+      - "@glint/template"
+      - supports-color
+    dev: false
+
   /ember-event-helpers@0.1.1:
     resolution:
       {
@@ -8677,20 +9078,6 @@ packages:
       ember-cli-version-checker: 5.1.2
       ember-source: 3.28.12(@babel/core@7.23.7)
     transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /ember-get-config@2.1.1:
-    resolution:
-      {
-        integrity: sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==,
-      }
-    engines: { node: 12.* || 14.* || >= 16 }
-    dependencies:
-      "@embroider/macros": 1.13.4
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - "@glint/template"
       - supports-color
     dev: false
 
@@ -8731,6 +9118,24 @@ packages:
       - supports-color
     dev: false
 
+  /ember-lifeline@7.0.0(@ember/test-helpers@2.9.4):
+    resolution:
+      {
+        integrity: sha512-2l51NzgH5vjN972zgbs+32rnXnnEFKB7qsSpJF+lBI4V5TG6DMy4SfowC72ZEuAtS58OVfwITbOO+RnM21EdpA==,
+      }
+    engines: { node: 16.* || >= 18 }
+    peerDependencies:
+      "@ember/test-helpers": ">= 1.0.0"
+    peerDependenciesMeta:
+      "@ember/test-helpers":
+        optional: true
+    dependencies:
+      "@ember/test-helpers": 2.9.4(@babel/core@7.23.7)(ember-source@3.28.12)
+      "@embroider/addon-shim": 1.9.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ember-load-initializers@2.1.2(@babel/core@7.23.7):
     resolution:
       {
@@ -8745,20 +9150,6 @@ packages:
       - supports-color
     dev: true
 
-  /ember-maybe-in-element@2.1.0:
-    resolution:
-      {
-        integrity: sha512-6WAzPbf4BNQIQzkur2+zRJJJ/PKQoujIYgFjrpj3fOPy8iRlxVUm0/B41qbFyg1LE6bVbg0cWbuESWEvJ9Rswg==,
-      }
-    engines: { node: 10.* || >= 12 }
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-cli-version-checker: 5.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /ember-modifier-manager-polyfill@1.2.0(@babel/core@7.23.7):
     resolution:
       {
@@ -8768,23 +9159,6 @@ packages:
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-version-checker: 2.2.0
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - "@babel/core"
-      - supports-color
-    dev: false
-
-  /ember-modifier@3.2.7(@babel/core@7.23.7):
-    resolution:
-      {
-        integrity: sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==,
-      }
-    engines: { node: 12.* || >= 14 }
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-string-utils: 1.1.0
-      ember-cli-typescript: 5.2.1
       ember-compatibility-helpers: 1.2.7(@babel/core@7.23.7)
     transitivePeerDependencies:
       - "@babel/core"
@@ -8807,6 +9181,27 @@ packages:
       ember-cli-string-utils: 1.1.0
       ember-source: 3.28.12(@babel/core@7.23.7)
     transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-modifier@4.2.0(@babel/core@7.26.0)(ember-source@3.28.12):
+    resolution:
+      {
+        integrity: sha512-BJ48eTEGxD8J7+lofwVmee7xDgNDgpr5dd6+MSu4gk+I6xb35099RMNorXY5hjjwMJEyi/IRR6Yn3M7iJMz8Zw==,
+      }
+    peerDependencies:
+      ember-source: ^3.24 || >=4.0
+    peerDependenciesMeta:
+      ember-source:
+        optional: true
+    dependencies:
+      "@embroider/addon-shim": 1.9.0
+      decorator-transforms: 2.3.0(@babel/core@7.26.0)
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-source: 3.28.12(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - "@babel/core"
       - supports-color
     dev: false
 
@@ -8951,15 +9346,21 @@ packages:
       - "@babel/core"
       - supports-color
 
-  /ember-style-modifier@1.0.0(@babel/core@7.23.7):
+  /ember-style-modifier@4.4.0(@babel/core@7.26.0)(@ember/string@4.0.0)(ember-source@3.28.12):
     resolution:
       {
-        integrity: sha512-ANkYpOeI3/tkRxVz750ymb8cQBqfBTKOUOz4RPRsNys8rlaBiaKEa95XLz1JWfCXCzjmqe8i2cIdnAMix+nb3A==,
+        integrity: sha512-gT1ckbhl1KSj5sWTo/8UChj98eZeE+mUmYoXw8VjwJgWP0wiTCibGZjVbC0WlIUd7umxuG61OQ/ivfF+sAiOEQ==,
       }
-    engines: { node: 14.* || >= 16 }
+    peerDependencies:
+      "@ember/string": ^3.1.1 || ^4.0.0
+      ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
     dependencies:
-      ember-cli-babel: 7.26.11
-      ember-modifier: 3.2.7(@babel/core@7.23.7)
+      "@ember/string": 4.0.0
+      "@embroider/addon-shim": 1.9.0
+      csstype: 3.1.3
+      decorator-transforms: 2.3.0(@babel/core@7.26.0)
+      ember-modifier: 4.2.0(@babel/core@7.26.0)(ember-source@3.28.12)
+      ember-source: 3.28.12(@babel/core@7.23.7)
     transitivePeerDependencies:
       - "@babel/core"
       - supports-color
@@ -9421,6 +9822,14 @@ packages:
         integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==,
       }
     engines: { node: ">=6" }
+
+  /escalade@3.2.0:
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: ">=6" }
+    dev: false
 
   /escape-goat@4.0.0:
     resolution:
@@ -10809,7 +11218,7 @@ packages:
       }
     engines: { node: ">= 4.0" }
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -12586,6 +12995,16 @@ packages:
     dependencies:
       has-tostringtag: 1.0.0
 
+  /is-subdir@1.2.0:
+    resolution:
+      {
+        integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==,
+      }
+    engines: { node: ">=4" }
+    dependencies:
+      better-path-resolve: 1.0.0
+    dev: false
+
   /is-symbol@1.0.4:
     resolution:
       {
@@ -12650,7 +13069,6 @@ packages:
         integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
       }
     engines: { node: ">=0.10.0" }
-    dev: true
 
   /is-wsl@1.1.0:
     resolution:
@@ -12859,6 +13277,15 @@ packages:
       }
     engines: { node: ">=4" }
     hasBin: true
+
+  /jsesc@3.0.2:
+    resolution:
+      {
+        integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==,
+      }
+    engines: { node: ">=6" }
+    hasBin: true
+    dev: false
 
   /json-buffer@3.0.0:
     resolution:
@@ -14894,6 +15321,13 @@ packages:
         integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==,
       }
 
+  /node-releases@2.0.18:
+    resolution:
+      {
+        integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==,
+      }
+    dev: false
+
   /node-watch@0.7.3:
     resolution:
       {
@@ -15944,6 +16378,13 @@ packages:
         integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==,
       }
 
+  /picocolors@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
+    dev: false
+
   /picomatch@2.3.1:
     resolution:
       {
@@ -16022,6 +16463,13 @@ packages:
     engines: { node: ">=8" }
     dependencies:
       find-up: 4.1.0
+
+  /pkg-entry-points@1.1.1:
+    resolution:
+      {
+        integrity: sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==,
+      }
+    dev: false
 
   /pkg-up@2.0.0:
     resolution:
@@ -19506,6 +19954,20 @@ packages:
       browserslist: 4.22.2
       escalade: 3.1.1
       picocolors: 1.0.0
+
+  /update-browserslist-db@1.1.1(browserslist@4.24.2):
+    resolution:
+      {
+        integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==,
+      }
+    hasBin: true
+    peerDependencies:
+      browserslist: ">= 4.21.0"
+    dependencies:
+      browserslist: 4.24.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+    dev: false
 
   /update-notifier@6.0.2:
     resolution:


### PR DESCRIPTION
This PR upgrades the following packages to support the Ember.js upgrade for smile-admin:

- ember-basic-dropdown
- @ember/string

These upgrades are required to update smile-admin to Ember 5.12.0. ([ref](https://github.com/smile-io/smile-admin/pull/6895))

### Breaking Changes
This update introduces a breaking change due to the ember-basic-dropdown upgrade. It requires adjustments in smile-admin to align with the changes introduced in ember-basic-dropdown version 8.0. [ref](https://ember-basic-dropdown.com/docs/migrate-7-0-to-8-0)