### PR TITLE
ACT-1699: Fix @xmldom/xmldom and uuid vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,9 +188,10 @@
       "handlebars": "^4.7.9",
       "serialize-javascript": "^7.0.5",
       "brace-expansion": "^5.0.5",
-      "@xmldom/xmldom@<0.8.12": "^0.8.12",
+      "@xmldom/xmldom@<0.8.13": "^0.8.13",
       "lodash@<=4.17.23": "^4.18.0",
-      "follow-redirects@<=1.15.11": "^1.16.0"
+      "follow-redirects@<=1.15.11": "^1.16.0",
+      "uuid@<14.0.0": "^14.0.0"
     },
     "patchedDependencies": {
       "minimatch@10.2.4": "patches/minimatch@10.2.4.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,10 @@ overrides:
   handlebars: ^4.7.9
   serialize-javascript: ^7.0.5
   brace-expansion: ^5.0.5
-  "@xmldom/xmldom@<0.8.12": ^0.8.12
+  "@xmldom/xmldom@<0.8.13": ^0.8.13
   lodash@<=4.17.23: ^4.18.0
   follow-redirects@<=1.15.11: ^1.16.0
+  uuid@<14.0.0: ^14.0.0
 
 patchedDependencies:
   minimatch@10.2.4:
@@ -2207,10 +2208,10 @@ packages:
         integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==,
       }
 
-  "@xmldom/xmldom@0.8.12":
+  "@xmldom/xmldom@0.8.13":
     resolution:
       {
-        integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==,
+        integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==,
       }
     engines: { node: ">=10.0.0" }
 
@@ -9934,10 +9935,10 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
-  uuid@8.3.2:
+  uuid@14.0.0:
     resolution:
       {
-        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
+        integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==,
       }
     hasBin: true
 
@@ -11813,7 +11814,7 @@ snapshots:
       "@webassemblyjs/ast": 1.14.1
       "@xtuc/long": 4.2.2
 
-  "@xmldom/xmldom@0.8.12": {}
+  "@xmldom/xmldom@0.8.13": {}
 
   "@xtuc/ieee754@1.2.0": {}
 
@@ -13636,7 +13637,7 @@ snapshots:
       testem: 3.16.0(handlebars@4.7.9)(underscore@1.13.8)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
-      uuid: 8.3.2
+      uuid: 14.0.0
       walk-sync: 2.2.0
       watch-detector: 1.0.2
       workerpool: 6.5.1
@@ -15842,7 +15843,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.7.2
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       which: 2.0.2
 
   node-releases@2.0.21: {}
@@ -17053,7 +17054,7 @@ snapshots:
 
   testem@3.16.0(handlebars@4.7.9)(underscore@1.13.8):
     dependencies:
-      "@xmldom/xmldom": 0.8.12
+      "@xmldom/xmldom": 0.8.13
       backbone: 1.6.1
       bluebird: 3.7.2
       charm: 1.0.2
@@ -17339,7 +17340,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache@2.4.0: {}
 


### PR DESCRIPTION
## Summary
- Linear: https://linear.app/smile/issue/ACT-1699/fix-xmldomxmldom-and-uuid-vulnerabilities-in-ember-smile-polaris
- Clears 5 audit advisories (4 high / 1 moderate) in `ember-smile-polaris`.
- Fix: tightens the existing `@xmldom/xmldom` override from `<0.8.12` → `<0.8.13` (`^0.8.13`), and adds a new `uuid@<14.0.0` → `^14.0.0` override. Both are transitive dev-only deps via `ember-cli > testem`.

## Audit
Before: `4 high | 1 moderate`
After:  `No known vulnerabilities found`


🤖 Generated with [Claude Code](https://claude.com/claude-code)