### PR TITLE
ACT-1825: mark repo as unmaintained, disable CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - "v*"
-  pull_request: {}
-  merge_group:
-  schedule:
-    - cron: "0 3 * * *" # daily, at 3am
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}

--- a/.github/workflows/gh-security-analysis.yml
+++ b/.github/workflows/gh-security-analysis.yml
@@ -1,10 +1,7 @@
 name: GitHub Actions Security Analysis
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['**']
+  workflow_dispatch:
 
 jobs:
   zizmor:

--- a/.github/workflows/merge_main_into_deprecate_ember_polaris.yml
+++ b/.github/workflows/merge_main_into_deprecate_ember_polaris.yml
@@ -1,9 +1,7 @@
 name: Merge main into deprecate-ember-polaris
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   merge_into_deprecate_ember_polaris:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# ember-smile-polaris
+> [!WARNING]
+> **This repository is no longer maintained.**
+> It is kept available for reference only. Issues and pull requests will not be reviewed.
 
-[![](https://github.com/smile-io/ember-smile-polaris/workflows/CI/badge.svg)](https://github.com/smile-io/ember-smile-polaris/actions)
+# ember-smile-polaris
 
 ![image](https://user-images.githubusercontent.com/5737342/26935493-c8c81c76-4c74-11e7-90dd-ff8b0fdc434e.png)
 


### PR DESCRIPTION
## Summary

- Switch `ci.yml`, `gh-security-analysis.yml`, and `merge_main_into_deprecate_ember_polaris.yml` to `workflow_dispatch`-only so pushes and PRs no longer trigger jobs. `publish_release.yml` is left unchanged (release-triggered; npm deprecation is out of scope per ACT-1825).
- Add a GitHub-alert callout above the README title noting the repo is no longer maintained, and drop the now-stale CI badge.

Linear: [ACT-1825](https://linear.app/smile/issue/ACT-1825/mark-ember-smile-polaris-as-unmaintained-disable-ci-add-readme-callout)

## Test plan

- [ ] Confirm Actions tab no longer shows runs queued from this PR's push event
- [ ] Confirm `Run zizmor 🌈` and `Tests` workflows remain visible under Actions but only run on manual dispatch
- [ ] Confirm README renders the warning block above the title on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)